### PR TITLE
Fix for branch with slashes

### DIFF
--- a/lib/Gitlab/Events/push.js
+++ b/lib/Gitlab/Events/push.js
@@ -1,4 +1,6 @@
+const GetBranchName = require('../../Util').GetBranchName;
 const EventResponse = require('../EventResponse');
+
 const UrlRegEx = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g;
 const RemoveUrlEmbedding = (url) => `<${url}>`;
 
@@ -11,7 +13,7 @@ class Push extends EventResponse {
   embed(data) {
     if (!data.commits || !data.commits.length) return;
 
-    const branch = data.ref ? data.ref.split('/')[2] : 'unknown';
+    const branch = GetBranchName(data.ref);
     const commits = data.commits;
     const commitCount = commits.length;
     let pretext = commits.map(commit => {
@@ -33,7 +35,7 @@ class Push extends EventResponse {
     if (!data.commits || !data.commits.length) return;
 
     const actor = data.user_username || data.user_name;
-    const branch = data.ref ? data.ref.split('/')[2] : 'unknown';
+    const branch = GetBranchName(data.ref);
     const commits = data.commits || [];
     const commitCount = commits.length;
     if (!commitCount) return '';

--- a/lib/Util/Branch.js
+++ b/lib/Util/Branch.js
@@ -1,0 +1,15 @@
+module.exports = function GetBranchName(ref) {
+  if (!ref) {
+    return 'unknown';
+  }
+
+  let splitedRef = ref.split('/');
+
+  // It slice /ref/heads and leave the rest, it should be a branch name
+  // for example refs/heads/feature/4 -> feature/4
+  if (splitedRef.length > 2) {
+    return splitedRef.slice(2).join('/');
+  }
+
+  return ref;
+};

--- a/lib/Util/Branch.js
+++ b/lib/Util/Branch.js
@@ -2,14 +2,8 @@ module.exports = function GetBranchName(ref) {
   if (!ref) {
     return 'unknown';
   }
-
-  let splitedRef = ref.split('/');
-
-  // It slice /ref/heads and leave the rest, it should be a branch name
+  
+  // Slice ref/heads and leave the rest, it should be a branch name
   // for example refs/heads/feature/4 -> feature/4
-  if (splitedRef.length > 2) {
-    return splitedRef.slice(2).join('/');
-  }
-
-  return ref;
+  return ref.split('/').slice(2).join('/');
 };

--- a/lib/Util/Branch.js
+++ b/lib/Util/Branch.js
@@ -2,7 +2,7 @@ module.exports = function GetBranchName(ref) {
   if (!ref) {
     return 'unknown';
   }
-  
+
   // Slice ref/heads and leave the rest, it should be a branch name
   // for example refs/heads/feature/4 -> feature/4
   return ref.split('/').slice(2).join('/');

--- a/lib/Util/index.js
+++ b/lib/Util/index.js
@@ -1,5 +1,6 @@
 const Pad = require('./Pad');
 const MergeDefault = require('./MergeDefault');
+const GetBranchName = require('./Branch');
 
 /**
  * Some utilities :)
@@ -22,6 +23,15 @@ class Util {
    */
   MergeDefault(...args) {
     return MergeDefault(...args);
+  }
+
+  /**
+   * Get branch name from ref
+   * @param {String} ref - ref from gitlab payload
+   * @return {String} Branch name
+   */
+  GetBranchName(...args) {
+    return GetBranchName(...args);
   }
 }
 

--- a/lib/Web.js
+++ b/lib/Web.js
@@ -58,7 +58,7 @@ app.post('/', (req, res) => {
   if (!eventResponse.embed && !eventResponse.text) return Log.warn(`GitLab | ${repo} - ${eventName}${actionText} ignored`);
 
   const handleError = (resp, channel) => {
-    const err = resp && resp.body || resp;
+    const err = (resp && resp.body) || resp;
     const errors = ['Forbidden', 'Missing Access'];
     if (!res || !err) return;
     if (errors.includes(err.message) || (err.error && errors.includes(err.error.message))) {

--- a/lib/Web.js
+++ b/lib/Web.js
@@ -5,6 +5,7 @@ const ChannelConfig = require('./Models/ChannelConfig');
 const GitlabEventHandler = require('./Gitlab/EventHandler');
 const bot = require('./Discord');
 const addons = require('yappybots-addons');
+const GetBranchName = require('./Util').GetBranchName;
 
 const app = express();
 const port = process.env.WEB_PORT || process.env.PORT || 8080;
@@ -82,7 +83,9 @@ app.post('/', (req, res) => {
       name: data.user ? data.user.name : data.user_username || data.user_name,
       id: data.user ? data.user.id : data.user_id,
     };
-    const branch = data.ref && data.ref ? data.ref.split('/')[2] : data.object_attributes.ref;
+
+    const branch = data.ref ? GetBranchName(data.ref) : data.object_attributes.ref;
+
     if (!channel) return;
     if (disabledEvents.includes(eventName) || disabledEvents.includes(`${eventName}${actionText}`)) return;
     if (ignoredUsers && (ignoredUsers.includes(actor.name) || ignoredUsers.includes(actor.id))) return;


### PR DESCRIPTION
Hi! First of all - thanks for the bot!

In our small team, we use branches with slashes in their names. For example `feature/41` or `fix/55`, where numbers are ids of tasks in our tracker. 
I found that the bot parse branch name with `.split('/')` and that is why bot show branch name incorrectly, for example `feature` instead of `feature/41`. 
So there is a fix for it.