### PR TITLE
Dockerise the bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+#######################################
+# Install node dependencies
+#######################################
+FROM node:alpine as install
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache bash git openssh
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --production
+
+#######################################
+# Setting up production
+#######################################
+FROM node:alpine
+COPY --from=install /app /app
+WORKDIR /app
+COPY lib lib
+ENV PORT=8080 \
+    IP="0.0.0.0" \
+    DISABLED_COMMANDS="exec,update,reload,reboot,eval"
+ENV DISCORD_TOKEN \
+    DB_URL \
+    DISCORD_CLIENT_ID \
+    DISCORD_CLIENT_SECRET \
+    DISCORD_CHANNEL_LOGGING \
+    BDPW_KEY \
+    LOG_LEVEL
+
+#######################################
+# Run application
+#######################################
+USER node
+CMD IS_DOCKER=true node lib/

--- a/lib/Discord/Client.js
+++ b/lib/Discord/Client.js
@@ -74,11 +74,16 @@ class Client extends DiscordClient {
         return this;
       }
 
+      const disabled = (process.env.DISABLED_COMMANDS || '').split(',');
+
       files.forEach(f => {
         try {
           let Command = require(`./Commands/${f}`);
 
           Command = new Command(this);
+
+          if (disabled.includes(Command.help.name)) return Log.info(`Skipping command: ${Command.help.name}`);
+
           Log.debug(`Command | Loading ${Command.help.name}. 👌`);
           Command.props.help.file = f;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ global.Log = require('./Util/Log');
 exports.Web = require('./Web');
 exports.Models = require('./Models');
 exports.Util = require('./Util');
-exports.YappyGithub = require('./Util/YappyGithub');
+if (process.env.IS_DOCKER !== 'true') exports.YappyGithub = require('./Util/YappyGithub');
 exports.Discord = require('./Discord');
 exports.Gitlab = require('./Gitlab');
 


### PR DESCRIPTION
I am deploying this bot in a docker container and these are the changes required to make a workable image

* Add `Dockerfile`
* Add the ability to disable some commands
* Disabled some commands by default in docker:
  * **exec** There isn't much to execute in a container
  * **update** A container is ephemeral, updating code stored in it is
    liable to be reverted
  * **reload** I'm not sure this works in normal context.
  * **reboot** An application inside of a container simply does have
    the ability to reboot itself
  * **eval** Is a feature I don't want downstream
* Added conditional to `index` to prevent loading `Util/YappyGithub`
  being loaded. It is going to be more trouble than it's worth to
  implement it to work in a container